### PR TITLE
Bugfix: Don't overwrite values with effect on setSfxLength

### DIFF
--- a/src/components/Head.tsx
+++ b/src/components/Head.tsx
@@ -7,7 +7,7 @@ import "../scss/head.css";
 
 interface Props {
   sfxLength: number;
-  setSfxLength: React.Dispatch<React.SetStateAction<number>>;
+  setSfxLength: (length: number) => void;
   feedback: number;
   setFeedback: React.Dispatch<React.SetStateAction<number>>;
   handleExport: () => void;


### PR DESCRIPTION
When updating `sfxLength` along with other fields (e.g. `op1Amps`), the effect on `sfxLength` would overwrite the change to the other values. This was only noticeable when increasing `sfxLength` as there would be no effect if `sfxLength` was being made shorter.

To avoid this problem, we remove the effect on `sfxLength`. This was already a sloppy misuse of `useEffect` to begin with so I'm not necessarily surprised to see that it lead to a bug. Instead, we create a helper function `updateSfxLength` which calls out to `setSfxLength` and also modifies the other fields if necessary. When we are trying to update `sfxLength` and the other fields at the same time (e.g. import a sfx binary, load data from uri on page load) we eschew `updateSfxLength` and use `setSfxLength` directly. This ensures that we don't attempt to make multiple writes to the same fields at once

Fixes #8 