### PR TITLE
Fix: don't render spin buttons on Chrome

### DIFF
--- a/src/scss/amp-control.css
+++ b/src/scss/amp-control.css
@@ -26,6 +26,14 @@
     width: 32px;
 }
 
+/* Hide the spin buttons on Chrome */
+.amp-control input[type="number"]::-webkit-outer-spin-button,
+.amp-control input[type="number"]::-webkit-inner-spin-button
+{
+    display: none;
+}
+
+/* Hide the spin buttons on Firefox */
 .amp-control input[type="number"] {
     appearance: textfield;
 }

--- a/src/scss/pitch-control.css
+++ b/src/scss/pitch-control.css
@@ -26,6 +26,14 @@
     width: 32px;
 }
 
+/* Hide the spin buttons on Chrome */
+.pitch-control input[type="number"]::-webkit-outer-spin-button,
+.pitch-control input[type="number"]::-webkit-inner-spin-button
+{
+    display: none;
+}
+
+/* Hide the spin buttons on Firefox */
 .pitch-control input[type="number"] {
     appearance: textfield;
 }


### PR DESCRIPTION
Chrome doesn't appear to respect `appearance: textfield` on number inputs.  This change resolves a minor cross-browser difference

Fixes #7 