### PR TITLE
Render controls that have no effect gray

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -213,6 +213,16 @@ function App() {
     }
   }
 
+  // Which controls don't contribute to the final sound? We'll gray these out
+  const ineffectiveOp4Amps = new Array(sfxLength).fill(false);
+  const ineffectiveOp4Pitches = op4Amps.map(p => p === 0);
+  const ineffectiveOp3Amps = ineffectiveOp4Pitches;
+  const ineffectiveOp3Pitches = op3Amps.map((p, ix) => p === 0 || ineffectiveOp4Pitches[ix]);
+  const ineffectiveOp2Amps = ineffectiveOp3Pitches;
+  const ineffectiveOp2Pitches = op2Amps.map((p, ix) => p === 0 || ineffectiveOp3Pitches[ix]);
+  const ineffectiveOp1Amps = ineffectiveOp2Pitches;
+  const ineffectiveOp1Pitches = op1Amps.map((p, ix) => p === 0 || ineffectiveOp2Pitches[ix]);
+
   return (
     <>
       <Head
@@ -232,6 +242,8 @@ function App() {
           ampValues={op1Amps}
           setAmpValues={setOp1Amps}
           pitchValues={op1Pitches}
+          ineffectivePitches={ineffectiveOp1Pitches}
+          ineffectiveAmps={ineffectiveOp1Amps}
           setPitchValues={setOp1Pitches}
         />
         <Operator
@@ -240,6 +252,8 @@ function App() {
           ampValues={op2Amps}
           setAmpValues={setOp2Amps}
           pitchValues={op2Pitches}
+          ineffectivePitches={ineffectiveOp2Pitches}
+          ineffectiveAmps={ineffectiveOp2Amps}
           setPitchValues={setOp2Pitches}
         />
         <Operator
@@ -248,6 +262,8 @@ function App() {
           ampValues={op3Amps}
           setAmpValues={setOp3Amps}
           pitchValues={op3Pitches}
+          ineffectivePitches={ineffectiveOp3Pitches}
+          ineffectiveAmps={ineffectiveOp3Amps}
           setPitchValues={setOp3Pitches}
         />
         <Operator
@@ -256,6 +272,8 @@ function App() {
           ampValues={op4Amps}
           setAmpValues={setOp4Amps}
           pitchValues={op4Pitches}
+          ineffectivePitches={ineffectiveOp4Pitches}
+          ineffectiveAmps={ineffectiveOp4Amps}
           setPitchValues={setOp4Pitches}
           highAmpWarning={7}
         />

--- a/src/components/AmpControl.tsx
+++ b/src/components/AmpControl.tsx
@@ -6,6 +6,7 @@ import "../scss/amp-control.css";
 interface Props {
   onChange: (values: Array<number>) => void;
   values: Array<number>;
+  ineffectiveAmps: Array<boolean>;
   highAmpWarning?: number;
 }
 
@@ -15,6 +16,7 @@ const maxValue = 8;
 export const AmpControl = ({
   onChange,
   values,
+  ineffectiveAmps,
   highAmpWarning,
 }: Props): ReactElement => {
   const handleValueUpdate = (ix: number) => (v: number) => {
@@ -39,6 +41,7 @@ export const AmpControl = ({
                 possibleValues={8}
                 pxPerValue={16}
                 warning={highAmpWarning !== undefined && v >= highAmpWarning}
+                isIneffective={ineffectiveAmps[ix]}
                 className="amp"
               />
               <input

--- a/src/components/Operator.tsx
+++ b/src/components/Operator.tsx
@@ -11,6 +11,8 @@ interface Props {
   ampValues: Array<number>;
   setAmpValues: React.Dispatch<React.SetStateAction<Array<number>>>;
   pitchValues: Array<number>;
+  ineffectiveAmps: Array<boolean>;
+  ineffectivePitches: Array<boolean>;
   setPitchValues: React.Dispatch<React.SetStateAction<Array<number>>>;
   highAmpWarning?: number;
 }
@@ -22,6 +24,8 @@ export const Operator = ({
   setAmpValues,
   pitchValues,
   setPitchValues,
+  ineffectiveAmps,
+  ineffectivePitches,
   highAmpWarning,
 }: Props): ReactElement => {
   return (
@@ -31,9 +35,14 @@ export const Operator = ({
         <AmpControl
           onChange={setAmpValues}
           values={ampValues}
+          ineffectiveAmps={ineffectiveAmps}
           highAmpWarning={highAmpWarning}
         />
-        <PitchControl onChange={setPitchValues} values={pitchValues} />
+        <PitchControl
+          onChange={setPitchValues}
+           values={pitchValues}
+           ineffectivePitches={ineffectivePitches}
+        />
       </div>
     </div>
   );

--- a/src/components/PitchControl.tsx
+++ b/src/components/PitchControl.tsx
@@ -7,12 +7,13 @@ import "../scss/pitch-control.css";
 interface Props {
   onChange: (values: Array<number>) => void;
   values: Array<number>;
+  ineffectivePitches: Array<boolean>;
 }
 
 const minValue = 0;
 const maxValue = 107;
 
-export const PitchControl = ({ values, onChange }: Props): ReactElement => {
+export const PitchControl = ({ values, onChange, ineffectivePitches }: Props): ReactElement => {
   const handleValueUpdate = (ix: number) => (v: number) => {
     const ret = [...values];
     if (!isNaN(v)) {
@@ -38,6 +39,7 @@ export const PitchControl = ({ values, onChange }: Props): ReactElement => {
               setValue={handleValueUpdate(ix)}
               possibleValues={maxValue + 1}
               pxPerValue={1}
+              isIneffective={ineffectivePitches[ix]}
               className="pitch"
             />
             <input

--- a/src/components/Slider.tsx
+++ b/src/components/Slider.tsx
@@ -7,6 +7,7 @@ interface Props {
   setValue: (value: number) => void;
   possibleValues: number;
   pxPerValue: number;
+  isIneffective: boolean;
   warning?: boolean;
   className?: string;
 }
@@ -16,6 +17,7 @@ export const Slider = ({
   setValue,
   possibleValues,
   pxPerValue,
+  isIneffective,
   warning,
   className,
 }: Props): ReactElement => {
@@ -38,7 +40,7 @@ export const Slider = ({
 
   // NOTE just hacking this in here instead of using a library like "classnames"
   // because this is the only place in the application I need to do this
-  const classes = ["slider", className, warning && "warning"]
+  const classes = ["slider", className, warning && "warning", isIneffective && "ineffective"]
     .filter((t) => t)
     .join(" ");
 

--- a/src/scss/index.css
+++ b/src/scss/index.css
@@ -6,6 +6,7 @@
   --color-amp-slider-on: #ffc04e;
   --color-pitch-slider-on: #ac45db;
   --color-slider-warning: #ff4646;
+  --color-slider-ineffective: #7a7676;
 
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
@@ -30,6 +31,7 @@
     --color-amp-slider-on: orange;
     --color-pitch-slider-on: #a100ea;
     --color-slider-warning: red;
+    --color-slider-ineffective: #696565;
   }
 
   a:hover {

--- a/src/scss/slider.css
+++ b/src/scss/slider.css
@@ -18,3 +18,7 @@
 .slider.warning .slider-inner-on {
     background-color: var(--color-slider-warning);
 }
+
+.slider.ineffective .slider-inner-on {
+    background-color: var(--color-slider-ineffective);
+}


### PR DESCRIPTION
If an operator's amplitude or the amplitude of operators later in the chain are 0, the controls of those operators have no effect on the final sound.  These are now rendered in gray.